### PR TITLE
Implement global timezone identifiers

### DIFF
--- a/src/main/php/text/ical/Calendar.class.php
+++ b/src/main/php/text/ical/Calendar.class.php
@@ -1,7 +1,7 @@
 <?php namespace text\ical;
 
 use lang\IllegalStateException;
-use util\{Date, Objects, TimeZone};
+use util\{Date, Objects};
 
 class Calendar implements IObject {
   use Properties;

--- a/src/main/php/text/ical/Calendar.class.php
+++ b/src/main/php/text/ical/Calendar.class.php
@@ -82,9 +82,10 @@ class Calendar implements IObject {
     // naming conventions defined in existing time zone specifications such
     // as the public-domain TZ database.
     if ('/' === $tzid[0]) {
-      return TimeZone::getByName(substr($tzid, 1))->translate(new Date($date->value()));
+      return ITimeZone::named(substr($tzid, 1))->convert($date->value());
     }
 
+    // Otherwise, search for a time zone definition
     foreach ($this->timezones as $timezone) {
       if ($tzid === $timezone->tzid()) return $timezone->convert($date->value());
     }

--- a/src/main/php/text/ical/TimeZoneInfo.class.php
+++ b/src/main/php/text/ical/TimeZoneInfo.class.php
@@ -33,7 +33,7 @@ class TimeZoneInfo implements IObject {
     return new self(
       gmdate('Ymd\THis', $ts + $from - $to),
       sprintf('%s%02d:%02d', $from < 0 ? '-' : '+', abs($from / 3600), abs($from % 3600) / 60),
-      sprintf('%s%02d:%02d', $to < 0 ? '-' : '+', abs($to / 3600), abs($to % 3600) / 60),
+      sprintf('%s%02d:%02d', $to < 0 ? '-' : '+', abs($to / 3600), abs($to % 3600) / 60)
     );
   }
 

--- a/src/main/php/text/ical/TimeZoneInfo.class.php
+++ b/src/main/php/text/ical/TimeZoneInfo.class.php
@@ -12,13 +12,29 @@ class TimeZoneInfo implements IObject {
    * @param string $dtstart
    * @param string $tzoffsetfrom
    * @param string $tzoffsetto
-   * @param string $rrule
+   * @param ?string $rrule
    */
-  public function __construct($dtstart, $tzoffsetfrom, $tzoffsetto, $rrule) {
+  public function __construct($dtstart, $tzoffsetfrom, $tzoffsetto, $rrule= null) {
     $this->dtstart= $dtstart;
     $this->tzoffsetfrom= $tzoffsetfrom;
     $this->tzoffsetto= $tzoffsetto;
     $this->rrule= $rrule;
+  }
+
+  /**
+   * Creates an instance from a time transition
+   * 
+   * @param  int $ts Timestamp for the transition
+   * @param  int $from UTC offset from
+   * @param  int $to UTC offset to
+   * @return self
+   */
+  public static function transition($ts, $from, $to): self {
+    return new self(
+      gmdate('Ymd\THis', $ts + $from - $to),
+      sprintf('%s%02d:%02d', $from < 0 ? '-' : '+', abs($from / 3600), abs($from % 3600) / 60),
+      sprintf('%s%02d:%02d', $to < 0 ? '-' : '+', abs($to / 3600), abs($to % 3600) / 60),
+    );
   }
 
   /** @return string */

--- a/src/test/php/text/ical/unittest/ICalendarTest.class.php
+++ b/src/test/php/text/ical/unittest/ICalendarTest.class.php
@@ -208,6 +208,22 @@ class ICalendarTest extends \unittest\TestCase {
     );
   }
 
+  #[Test, Values([['19970714T173000', 'local time'], ['19970714T173000Z', 'UTC time']])]
+  public function convert_date_with_global_utc($date, $remark) {
+    $calendar= (new ICalendar())->read(
+      "BEGIN:VCALENDAR\r\n".
+      "BEGIN:VEVENT\r\n".
+      "DTSTART;TZID=/UTC:{$date}\r\n".
+      "END:VEVENT\r\n".
+      "END:VCALENDAR"
+    );
+    $this->assertEquals(
+      new Date('1997-07-14 17:30:00 UTC'),
+      $calendar->date($calendar->events()->first()->dtstart()),
+      $remark
+    );
+  }
+
   #[Test, Values([['19970714T193000', 'local time'], ['19970714T173000Z', 'UTC time']])]
   public function convert_date_with_timezone($date, $remark) {
     $calendar= (new ICalendar())->read(

--- a/src/test/php/text/ical/unittest/ICalendarTest.class.php
+++ b/src/test/php/text/ical/unittest/ICalendarTest.class.php
@@ -193,6 +193,22 @@ class ICalendarTest extends \unittest\TestCase {
   }
 
   #[Test, Values([['19970714T193000', 'local time'], ['19970714T173000Z', 'UTC time']])]
+  public function convert_date_with_global_timezone($date, $remark) {
+    $calendar= (new ICalendar())->read(
+      "BEGIN:VCALENDAR\r\n".
+      "BEGIN:VEVENT\r\n".
+      "DTSTART;TZID=/Europe/Berlin:{$date}\r\n".
+      "END:VEVENT\r\n".
+      "END:VCALENDAR"
+    );
+    $this->assertEquals(
+      new Date('1997-07-14 19:30:00 Europe/Berlin'),
+      $calendar->date($calendar->events()->first()->dtstart()),
+      $remark
+    );
+  }
+
+  #[Test, Values([['19970714T193000', 'local time'], ['19970714T173000Z', 'UTC time']])]
   public function convert_date_with_timezone($date, $remark) {
     $calendar= (new ICalendar())->read(
       "BEGIN:VCALENDAR\r\n".
@@ -212,7 +228,7 @@ class ICalendarTest extends \unittest\TestCase {
       "END:DAYLIGHT\r\n".
       "END:VTIMEZONE\r\n".
       "BEGIN:VEVENT\r\n".
-      "DTSTART;TZID=W. Europe Standard Time:".$date."\r\n".
+      "DTSTART;TZID=W. Europe Standard Time:{$date}\r\n".
       "END:VEVENT\r\n".
       "END:VCALENDAR"
     );


### PR DESCRIPTION
From https://stackoverflow.com/questions/42919630/whats-vtimezone-used-for-in-icalendar-why-not-just-utc-time:

> `DTEND;TZID=Asia/Shanghai:20170324T213000`
> 
> An iCalendar parser will look at that TZID parameter, and then look for a VTIMEZONE component whose TZID property matches it. Because your iCalendar object does not have such a VTIMEZONE, the iCalendar parser technically doesn't know how to interpret that date. The TZID parameter is merely treated as a unique identifier. It does not have any meaning in and of itself.
>
> If you want a date to be formatted under a specific timezone, but you do not want to include a VTIMEZONE component in your iCalendar object, you can use a global timezone ID. Global timezone IDs are different from normal TZID parameters because they begin with a forward slash:
> 
> `DTEND;TZID=/Asia/Shanghai:20170324T213000`
>
> The downside to global timezone IDs is that the iCalendar specification does NOT specify how these IDs are supposed to be interpreted by the parser. However, in practice, I would imagine that out of all the parsers that support global IDs, most of them probably treat them as Olson IDs.

See also https://www.rfc-editor.org/rfc/rfc5545#section-3.8.3.1